### PR TITLE
Add log parser with improved regex

### DIFF
--- a/log_parser.py
+++ b/log_parser.py
@@ -1,0 +1,5 @@
+import re
+
+LOG_PATTERN = re.compile(
+    r"^(?P<time>\w+\s+\d+\s+\d+:\d+:\d+).*?query\[(?P<qtype>[^\]]+)\]\s+(?P<domain>\S+)\s+from\s+(?P<ip>\S+)"
+)


### PR DESCRIPTION
## Summary
- implement a log parser regex in `log_parser.py`
- the pattern extracts time, query type, domain, and IP

## Testing
- `python - <<'EOF'
import re
from log_parser import LOG_PATTERN

line = "Aug  8 18:27:51 host dnsmasq[1234]: query[A] example.com from 192.168.1.1"
match = LOG_PATTERN.match(line)
print(match.groupdict())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68456a76b78c8325a88e58a2ba60ab64